### PR TITLE
Fix EOF issue prevent new line from being appended if the line did no…

### DIFF
--- a/netcat.awk
+++ b/netcat.awk
@@ -6,13 +6,17 @@ BEGIN {
     print "OUT:\n    send input to network"
     exit
   }
+
   FILE = ARGV[1]; ARGV[1] = ""
   if (Port ==  0) Port = 9999
-
+  ORS = RS = "\n"
   BINMODE = "rw"
   HttpService = "/inet/tcp/" Port "/0/0"
   while(( getline < FILE ) > 0 ) {
-    print $0 |& HttpService 
+    # RT not empty if it matched the RS (\n, etc.)
+    # So print the ORS if the line has a RS
+    # Otherwise don't print the ORS
+    printf "%s%s",$0,RT?ORS:"" |& HttpService
   }
   close(HttpService)
 }


### PR DESCRIPTION
…t have a newline

AWK... So, the script would add a new line to the end of the file which changed the file.  The update uses the RT to match against the RS and if it matches (ie the line has a RS) then inserts one at the end of the row.  If the line does not have match with the RS then no ORS is output...